### PR TITLE
Add option for rebuilding existing pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ To bootstrap a bilingual module which uses apertium-separable,
 $ python3 apertium-init.py foo-bar --with-separable
 ```
 
+### Adding features to an existing module
+
+Apertium-init can reconfigure an existing module or pair. For example, to add apertium-separable to an existing pair:
+
+```bash
+$ python3 apertium-init.py foo-bar -r --with-separable
+```
+
+Note that all desired options must be specified. If the foo-bar pair used apertium-anaphora, the above command would remove it.
+
 ### Pushing to Github
 
 To bootstrap a module or pair and also add it to the [apertium incubator](https://github.com/apertium/apertium-incubator),

--- a/apertium-init.py
+++ b/apertium-init.py
@@ -296,8 +296,8 @@ def main(cli_args):  # type: (List[str]) -> None
             fname = make_replacements(filename, replacements, conditionals)
             if os.path.exists(os.path.join(args.destination, fname)):
                 files_to_delete.append(filename)
-        for r in files_to_delete:
-            del files[r]
+        for filename in files_to_delete:
+            del files[filename]
     elif os.path.exists(args.destination):
         sys.stderr.write('Directory {} already exists, quitting.\n'.format(args.destination))
         sys.exit(-1)

--- a/test.py
+++ b/test.py
@@ -110,6 +110,13 @@ class TestUnknownCodeModule(TestModule, unittest.TestCase):
         apertium_init.main([cls.name])
 
 
+class TestRebuildModule(TestModule, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        apertium_init.main([cls.name, '-a=hfst'])
+        apertium_init.main([cls.name, '-a=hfst', '-r', '--with-twoc'])
+
+
 class TestPair(TestModule, unittest.TestCase):
     name = 'eng-cat'
     path = make_path(name)
@@ -187,6 +194,13 @@ class TestPairWithChunking(TestPair, unittest.TestCase):
 
 class TestPairWithRecursive(TestPair, unittest.TestCase):
     other_args = ['--transfer=rtx']
+
+
+class TestRebuildPair(TestPair, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        TestPair.setUpClass()
+        apertium_init.main([cls.name, '-r', '--with-anaphora'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds `-r` or `--rebuild` which builds a module or pair in an existing directory. Existing data files are left untouched, any new ones are added, and existing setup files (`Makefile.am`, `modes.xml`, `README`, etc.) are copied to a backup directory and replaced.

```bash
# make a module
apertium-init.py wad -a=hfst
...
# turns out we wanted twoc in there
apertium-init.py wad -r -a=hfst --with-twoc
```