### PR TITLE
fix lexd and add license notice

### DIFF
--- a/hfst-language-module/Makefile.am
+++ b/hfst-language-module/Makefile.am
@@ -39,10 +39,12 @@ if_twoc}}{{if_lexd
 	cat $< | grep -v 'Dir/RL' > $@
 
 .deps/$(LANG1).RL.lexd.hfst: .deps/$(LANG1).RL.lexd
-	lexd $< | hfst-txt2fst -o $@
+	lexd $< .deps/$(LANG1).RL.lexd.att
+	hfst-txt2fst .deps/$(LANG1).RL.lexd.att -o $@
 
 .deps/$(LANG1).LR.lexd.hfst: .deps/$(LANG1).LR.lexd
-	lexd $< | hfst-txt2fst -o $@
+	lexd $< .deps/$(LANG1).LR.lexd.att
+	hfst-txt2fst .deps/$(LANG1).LR.lexd.att -o $@
 if_lexd}}{{ifnot_lexd
 .deps/$(LANG1).RL.lexc: $(BASENAME).$(LANG1).lexc .deps/.d
 	cat $< | grep -v 'Dir/LR' > $@
@@ -138,7 +140,8 @@ if_lexd}}
 ifnot_lexd}}{{if_lexd
 .deps/$(LANG1).LR-debug.hfst: $(BASENAME).$(LANG1).lexd .deps/.d
 	cat $< | grep -v 'Dir/RL' | grep -v 'Use/Circ' > .deps/$(LANG1).LR-debug.lexd
-	lexd .deps/$(LANG1).LR-debug.lexd | hfst-txt2fst -o .deps/$(LANG1).LR-debug.lexd.hfst
+	lexd .deps/$(LANG1).LR-debug.lexd .deps/$(LANG1).LR-debug.lexd.att
+	hfst-txt2fst .deps/$(LANG1).LR-debug.lexd.att -o .deps/$(LANG1).LR-debug.lexd.hfst
 	hfst-compose-intersect -1 .deps/$(LANG1).LR-debug.lexd.hfst -2 .deps/$(LANG1).twol.hfst -o $@
 
 .deps/$(LANG1).lexd.hfst: .deps/$(LANG1).RL.lexd.hfst

--- a/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.lexd
+++ b/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.lexd
@@ -69,7 +69,7 @@ LEXICON Punctuation
 \[<lpar>:\[
 )<rpar>:)
 \\<sent>:\\
-/<sent>:/
+\/<sent>:\/
 
 
 # Resources:

--- a/main.py
+++ b/main.py
@@ -364,6 +364,13 @@ def main(cli_args=None):  # type: (Optional[List[str]]) -> None
         print('To push your new local repository to incubator in the {} organisation on GitHub:'.format(organization_name))
         print('\tapertium-init.py --pe {} {}'.format(args.destination, repository_name))
 
+    if not args.rebuild:
+        print("""
+The directory you just created includes a GPLv3-or-later license.
+If you would like to license it differently, please adjust or replace the COPYING file accordingly.
+Please note that code included in the Apertium project should be GPLv2-or-later-compatible.
+""")
+
     push_hook = os.path.join(args.destination, '.git/hooks/pre-push')
     if not os.path.exists(push_hook):
         with open(push_hook, 'w') as f:


### PR DESCRIPTION
* rewrite lexd recipes so that errors halt overall
compilation (i.e. since pipefail isn't default)
* escape / in lexd punctuation lexicon (closes #106)
* print notice of default GPLv3 license after bootstrapping (closes #102)