### PR TITLE
Assorted minor fixes

### DIFF
--- a/hfst-language-module/modes.xml
+++ b/hfst-language-module/modes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modes>
 
-  <mode name="{{languageCode}}-twol" install="yes">
+  <mode name="{{languageCode}}-twol" install="no">
     <pipeline>
       <program name="hfst-strings2fst -S"/>
       <program name="hfst-compose-intersect">
@@ -19,13 +19,23 @@
     </pipeline>
   </mode>
 
-  <mode name="{{languageCode}}-lexc" install="yes">
+{{ifnot_lexd
+  <mode name="{{languageCode}}-lexc" install="no">
     <pipeline>
       <program name="hfst-lookup">
         <file name=".deps/{{languageCode}}.LR.lexc.hfst"/>
       </program>
     </pipeline>
   </mode>
+ifnot_lexd}}{{if_lexd
+  <mode name="{{languageCode}}-lexd" install="no">
+    <pipeline>
+      <program name="hfst-lookup">
+        <file name=".deps/{{languageCode}}.LR.lexd.hfst"/>
+      </program>
+    </pipeline>
+  </mode>
+if_lexd}}
 
   <mode name="{{languageCode}}-gener" install="yes">
     <pipeline>

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ __copyright__ = 'Copyright 2014--2021, Sushain K. Cherivirala, Kevin Brubeck Unh
 __credits__ = ['Sushain K. Cherivirala', 'Kevin Brubeck Unhammer', 'Jonathan North Washington', 'Shardul Chiplunkar', 'Daniel Swanson']
 __license__ = 'GPLv3+'
 __status__ = 'Production'
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 import argparse
 import base64

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import shlex
 import stat
 import subprocess
 import sys
+import urllib.error
 import urllib.request
 import zlib
 
@@ -217,7 +218,8 @@ def main(cli_args=None):  # type: (Optional[List[str]]) -> None
     parser.add_argument('-r', '--rebuild', help='construct module or pair with different features using existing files',
                         action='store_true', default=False)
 
-    parser.add_argument('-a', '--analyser', help='analyser to use for all languages', choices=['lt', 'lttoolbox', 'hfst', 'lexd', 'giella'], default='lt')
+    parser.add_argument('-a', '--analyser', '--analysers', help='analyser to use for all languages', choices=['lt', 'lttoolbox', 'hfst', 'lexd', 'giella'],
+                        default='lt')
     parser.add_argument('--analyser1', '--a1', help='analyser to use for first language of pair', choices=['lt', 'lttoolbox', 'hfst', 'lexd', 'giella'],
                         default='lt')
     parser.add_argument('--analyser2', '--a2', help='analyser to use for second language of pair', choices=['lt', 'lttoolbox', 'hfst', 'lexd', 'giella'],

--- a/test.py
+++ b/test.py
@@ -93,6 +93,16 @@ class TestInvalidModule(unittest.TestCase):
         shutil.rmtree(path)
 
 
+class TestInvalidPair(unittest.TestCase):
+    def test_no_giella_with_tagger_args_left(self):
+        with self.assertRaises(SystemExit):
+            apertium_init.main(['eng-spa', '--analyser1=giella', '--no-prob1'])
+
+    def test_no_giella_with_tagger_args_right(self):
+        with self.assertRaises(SystemExit):
+            apertium_init.main(['eng-spa', '--analyser2=giella', '--no-rlx2'])
+
+
 class TestLttoolboxModule(TestModule, unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
* Don't install modes that rely on intermediate files
* Generate xyz-lexd mode rather than xyz-lexc when appropriate (closes #109)
* Explictly import urllib.error so mypy doesn't complain
* Allow both sides of a pair to be specified with `--analysers` in addition to `--analyser`, since the documentation has `--analysers` and it seems sensible to allow the plural
* Add a couple of tests