### PR TITLE
modernise configure.ac a bit

### DIFF
--- a/bilingual-module/configure.ac
+++ b/bilingual-module/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.52)
 
-AC_INIT([Apertium {{languageName1}}-{{languageName2}}], [0.1.0], [{{email}}], [apertium-{{languageCode1}}-{{languageCode2}}], [https://wiki.apertium.org/wiki/Apertium-{{languageCode1}}-{{languageCode2}}])
+AC_INIT([Apertium {{languageName1}}-{{languageName2}}],[0.1.0],[https://github.com/apertium/apertium-{{languageCode1}}-{{languageCode2}}/issues], [apertium-{{languageCode1}}-{{languageCode2}}], [https://wiki.apertium.org/wiki/Apertium-{{languageCode1}}-{{languageCode2}}])
 AM_INIT_AUTOMAKE
 AC_PROG_AWK
 
@@ -44,4 +44,5 @@ PKG_CHECK_MODULES(REGTEST, apertium-regtest >= 0.0.1, [],
 
 AP_MKINCLUDE
 
-AC_OUTPUT([Makefile])
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/hfst-language-module/configure.ac
+++ b/hfst-language-module/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.52)
 
-AC_INIT([Apertium {{languageName}}], [0.1.0], [{{email}}], [apertium-{{languageCode}}], [https://wiki.apertium.org/wiki/Apertium-{{languageCode}}])
+AC_INIT([Apertium {{languageName}}], [0.1.0], [https://github.com/apertium/apertium-{{languageCode}}/issues], [apertium-{{languageCode}}], [https://wiki.apertium.org/wiki/Apertium-{{languageCode}}])
 AM_INIT_AUTOMAKE
 AC_PROG_AWK
 
@@ -19,4 +19,5 @@ PKG_CHECK_MODULES(REGTEST, apertium-regtest >= 0.0.1, [],
 
 AP_MKINCLUDE
 
-AC_OUTPUT([Makefile apertium-{{languageCode}}.pc])
+AC_CONFIG_FILES([Makefile apertium-{{languageCode}}.pc])
+AC_OUTPUT

--- a/lttoolbox-language-module/configure.ac
+++ b/lttoolbox-language-module/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.52)
 
-AC_INIT([Apertium {{languageName}}], [0.1.0], [{{email}}], [apertium-{{languageCode}}], [https://wiki.apertium.org/wiki/Apertium-{{languageCode}}])
+AC_INIT([Apertium {{languageName}}], [0.1.0], [https://github.com/apertium/apertium-{{languageCode}}/issues], [apertium-{{languageCode}}], [https://wiki.apertium.org/wiki/Apertium-{{languageCode}}])
 AM_INIT_AUTOMAKE
 AC_PROG_AWK
 
@@ -13,4 +13,5 @@ PKG_CHECK_MODULES(REGTEST, apertium-regtest >= 0.0.1, [],
 
 AP_MKINCLUDE
 
-AC_OUTPUT([Makefile apertium-{{languageCode}}.pc])
+AC_CONFIG_FILES([Makefile apertium-{{languageCode}}.pc])
+AC_OUTPUT


### PR DESCRIPTION
after I used apertium-init today autotools scolded me of these outdated autoconf stuff, this is pretty much what autoupdate did. I also changed bug-report from email to github issues cause that's what people use these days.