### PR TITLE
Make almost all rule files language-independent

### DIFF
--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.arx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.arx
@@ -87,6 +87,7 @@
 
 	<section-markables>
 
+      <!-- example rule, gives a -1 score to any antecedent that is part of a PP
 		<markable n="PP">
 			<pattern>
 				<pattern-item n="prep"/>
@@ -162,58 +163,8 @@
 				<pattern-item n="np" head="t"/>
 			</pattern>
 
-			<score n="-1"/> <!-- This gives a -1 score to any antecedent that is part of a PP -->
-		</markable>
-
-		<markable n="IP">
-			<pattern>
-				<pattern-item n="ind"/>
-				<pattern-item n="nom"/>
-			</pattern>
-			<pattern>
-				<pattern-item n="ind"/>
-				<pattern-item n="adj"/>
-				<pattern-item n="nom"/>
-			</pattern>
-
-			<score n="-1"/> <!-- This gives a -1 score to any antecedent that is part of a Indefinite Noun Phrase -->
-		</markable>
-
-		<markable n="PNP">
-			<pattern>
-				<pattern-item n="np"/>
-			</pattern>
-
-			<score n="1"/> <!-- This gives a +1 score to any antecedent that is part of a Proper Noun -->
-		</markable>
-
-		<markable n="AdNP"> <!-- NP that is being addressed , for example, "Madam President, ..."-->
-			<pattern>
-				<pattern-item n="nom"/>
-				<pattern-item n="com"/>
-			</pattern>
-
-			<pattern>
-				<pattern-item n="nom"/>
-				<pattern-item n="nom"/>
-				<pattern-item n="com"/>
-			</pattern>
-
-			<score n="-2"/>
-		</markable>
-
-
-		<markable n="Cop">
-			<pattern>
-				<pattern-item n="nom"/>
-				<pattern-item n="cop"/>
-				<pattern-item n="anaphor"/>
-			</pattern>
-
-			<score n="-5" parameter="detpos"/>
-		</markable>
-
-		<!-- Noun, CopulaVerb, Anaphor - in this order, would mean that the noun can't be its antecedent -->
+			<score n="-1"/>
+		</markable> -->
 
 	</section-markables>
 

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.arx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.arx
@@ -87,6 +87,21 @@
 
 	<section-markables>
 
+		<markable n="AdNP"> <!-- NP that is being addressed , for example, "Senyora presidenta, ..."-->
+			<pattern>
+				<pattern-item n="nom"/>
+				<pattern-item n="com"/>
+			</pattern>
+
+			<pattern>
+				<pattern-item n="nom"/>
+				<pattern-item n="nom"/>
+				<pattern-item n="com"/>
+			</pattern>
+
+			<score n="-2"/>
+		</markable>
+
       <!-- example rule, gives a -1 score to any antecedent that is part of a PP
 		<markable n="PP">
 			<pattern>

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.dix
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.dix
@@ -97,7 +97,9 @@
 
    <section id="main" type="standard">
       <!-- Define entries within <e> here. -->
-      <e><p><l>house<s n="n"/></l><r>casa<s n="n"/><s n="f"/></r></p></e>
+      <!-- example:
+           <e><p><l>house<s n="n"/></l><r>casa<s n="n"/><s n="f"/></r></p></e>
+      -->
 
       <e><re>[.\?;:!…¿¶]</re><p><l><s n="sent"/></l><r><s n="sent"/></r></p></e>
       <e><re>,</re>          <p><l><s n="cm"/></l>  <r><s n="cm"/></r></p></e>

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.lrx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.lrx
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
-  <!--
+  <!-- example:
     This rule chooses "energía" as the translation of "power" when it is preceded by "wind".
     Add your own rules within <rule> here, using the resources below as a guide
-  -->
-
   <rule>
     <match lemma="wind"/>
     <match lemma="power" tags="n.*">
       <select lemma="energía" tags="n.*"/>
     </match>
   </rule>
+  -->
 </rules>
 
 <!--

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.lsx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.lsx
@@ -44,7 +44,6 @@
       ^take<vblex>...$ [noun phrase] ^out<adv>$
       with
       ^take# out<vblex>...$ [noun phrase]
-  -->
 
 		<e lm="take out" c="sacar">
 			<p>
@@ -58,6 +57,7 @@
 				<r></r>
 			</p>
 		</e>
+  -->
 	</section>
 </dictionary>
 

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.rtx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.rtx
@@ -38,8 +38,8 @@ det: (if (1.det_type = def or 1.det_type = ind)
 !!!!!!!!!!!!!!!
 
 ! Example rule:
-! Input:  ^ראש<n><m><sg>/head<n><f><sg>$ ^גדול<adj><m><sg>/big<adj><m><sg>$
-! Output: ^big<adj><f><sg>$ ^head<n><f><sg>$
+! Input:  ^ראש<n><m><sg>/hovud<n><nt><sg>$ ^גדול<adj><m><sg>/stor<adj><m><sg>$
+! Output: ^stor<adj><nt><sg>$ ^hovud<n><nt><sg>$
 ! NP -> n.$number adj { 2[gender=1.gender, number=1.number] _ 1 } ;
 
 ! Resources:

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.rtx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode1}}-{{languageCode2}}.rtx
@@ -37,7 +37,10 @@ det: (if (1.det_type = def or 1.det_type = ind)
 !! REDUCTION RULES
 !!!!!!!!!!!!!!!
 
-NP -> n.$number adj { 2[gender=1.gender, number=1.number] _ 1 } ;
+! Example rule:
+! Input:  ^ראש<n><m><sg>/head<n><f><sg>$ ^גדול<adj><m><sg>/big<adj><m><sg>$
+! Output: ^big<adj><f><sg>$ ^head<n><f><sg>$
+! NP -> n.$number adj { 2[gender=1.gender, number=1.number] _ 1 } ;
 
 ! Resources:
 ! https://wiki.apertium.org/wiki/Apertium-recursive

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.arx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.arx
@@ -87,6 +87,7 @@
 
 	<section-markables>
 
+      <!-- Example: This gives a -1 score to any antecedent that is part of a PP
 		<markable n="PP">
 			<pattern>
 				<pattern-item n="prep"/>
@@ -162,58 +163,9 @@
 				<pattern-item n="np" head="t"/>
 			</pattern>
 
-			<score n="-1"/> <!-- This gives a -1 score to any antecedent that is part of a PP -->
+			<score n="-1"/>
 		</markable>
-
-		<markable n="IP">
-			<pattern>
-				<pattern-item n="ind"/>
-				<pattern-item n="nom"/>
-			</pattern>
-			<pattern>
-				<pattern-item n="ind"/>
-				<pattern-item n="adj"/>
-				<pattern-item n="nom"/>
-			</pattern>
-
-			<score n="-1"/> <!-- This gives a -1 score to any antecedent that is part of a Indefinite Noun Phrase -->
-		</markable>
-
-		<markable n="PNP">
-			<pattern>
-				<pattern-item n="np"/>
-			</pattern>
-
-			<score n="1"/> <!-- This gives a +1 score to any antecedent that is part of a Proper Noun -->
-		</markable>
-
-		<markable n="AdNP"> <!-- NP that is being addressed , for example, "Madam President, ..."-->
-			<pattern>
-				<pattern-item n="nom"/>
-				<pattern-item n="com"/>
-			</pattern>
-
-			<pattern>
-				<pattern-item n="nom"/>
-				<pattern-item n="nom"/>
-				<pattern-item n="com"/>
-			</pattern>
-
-			<score n="-2"/>
-		</markable>
-
-
-		<markable n="Cop">
-			<pattern>
-				<pattern-item n="nom"/>
-				<pattern-item n="cop"/>
-				<pattern-item n="anaphor"/>
-			</pattern>
-
-			<score n="-5" parameter="detpos"/>
-		</markable>
-
-		<!-- Noun, CopulaVerb, Anaphor - in this order, would mean that the noun can't be its antecedent -->
+      -->
 
 	</section-markables>
 

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.arx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.arx
@@ -87,6 +87,21 @@
 
 	<section-markables>
 
+		<markable n="AdNP"> <!-- NP that is being addressed , for example, "Senyora presidenta, ..."-->
+			<pattern>
+				<pattern-item n="nom"/>
+				<pattern-item n="com"/>
+			</pattern>
+
+			<pattern>
+				<pattern-item n="nom"/>
+				<pattern-item n="nom"/>
+				<pattern-item n="com"/>
+			</pattern>
+
+			<score n="-2"/>
+		</markable>
+
       <!-- Example: This gives a -1 score to any antecedent that is part of a PP
 		<markable n="PP">
 			<pattern>

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.lrx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.lrx
@@ -3,14 +3,13 @@
   <!--
     This rule chooses "energía" as the translation of "power" when it is preceded by "wind".
     Add your own rules within <rule> here, using the resources below as a guide
-  -->
-
   <rule>
     <match lemma="wind"/>
     <match lemma="power" tags="n.*">
       <select lemma="energía" tags="n.*"/>
     </match>
   </rule>
+  -->
 </rules>
 
 <!--

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.lsx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.lsx
@@ -44,8 +44,6 @@
       ^take<vblex>...$ [noun phrase] ^out<adv>$
       with
       ^take# out<vblex>...$ [noun phrase]
-  -->
-
 		<e lm="take out" c="sacar">
 			<p>
 				<l>take<s n="vblex"/></l>
@@ -58,6 +56,8 @@
 				<r></r>
 			</p>
 		</e>
+  -->
+
 	</section>
 </dictionary>
 

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.rtx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.rtx
@@ -38,8 +38,8 @@ det: (if (1.det_type = def or 1.det_type = ind)
 !!!!!!!!!!!!!!!
 
 ! Example rule:
-! Input:  ^ראש<n><m><sg>/head<n><f><sg>$ ^גדול<adj><m><sg>/big<adj><m><sg>$
-! Output: ^big<adj><f><sg>$ ^head<n><f><sg>$
+! Input:  ^ראש<n><m><sg>/hovud<n><nt><sg>$ ^גדול<adj><m><sg>/stor<adj><nt><sg>$
+! Output: ^stor<adj><nt><sg>$ ^hovud<n><nt><sg>$
 ! NP -> n.$number adj { 2[gender=1.gender, number=1.number] _ 1 } ;
 
 ! Resources:

--- a/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.rtx
+++ b/bilingual-module/apertium-{{languageCode1}}-{{languageCode2}}.{{languageCode2}}-{{languageCode1}}.rtx
@@ -37,7 +37,10 @@ det: (if (1.det_type = def or 1.det_type = ind)
 !! REDUCTION RULES
 !!!!!!!!!!!!!!!
 
-NP -> n.$number adj { 2[gender=1.gender, number=1.number] _ 1 } ;
+! Example rule:
+! Input:  ^ראש<n><m><sg>/head<n><f><sg>$ ^גדול<adj><m><sg>/big<adj><m><sg>$
+! Output: ^big<adj><f><sg>$ ^head<n><f><sg>$
+! NP -> n.$number adj { 2[gender=1.gender, number=1.number] _ 1 } ;
 
 ! Resources:
 ! https://wiki.apertium.org/wiki/Apertium-recursive

--- a/hfst-language-module/README
+++ b/hfst-language-module/README
@@ -93,7 +93,6 @@ For more information
 
 * https://wiki.apertium.org/wiki/Installation
 * https://wiki.apertium.org/wiki/apertium-{{languageCode}}
-* https://wiki.apertium.org/wiki/Using_an_lttoolbox_dictionary
 
 Help and support
 -------------------------------------------------------------------------------

--- a/hfst-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
+++ b/hfst-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
@@ -28,6 +28,7 @@
 
   <section id="main" type="standard">
     <!-- Define entries within <e> here. See https://wiki.apertium.org/wiki/Post-generator for more information.-->
+    <!-- Example: This changes "a" to "an" before vowels
     <e>
       <p>
         <l><a/>a<b/></l>
@@ -35,6 +36,7 @@
       </p>
       <par n="vocals"/>
     </e>
+    -->
   </section>
 </dictionary>
 

--- a/hfst-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
+++ b/hfst-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
@@ -1,42 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dictionary>
   <alphabet/>
-
   <sdefs>
-    <sdef n="n" c="Noun"/>
+    <sdef n="prn"/>
   </sdefs>
-
   <pardefs>
-    <pardef n="vocals">
+
+    <pardef n="contrac">
       <e>
-        <i>a</i>
+        <i>ls<b/></i>
       </e>
       <e>
-        <i>e</i>
-      </e>
-      <e>
-        <i>i</i>
-      </e>
-      <e>
-        <i>o</i>
-      </e>
-      <e>
-        <i>u</i>
+        <i>l<b/></i>
       </e>
     </pardef>
+
   </pardefs>
 
   <section id="main" type="standard">
+
     <!-- Define entries within <e> here. See https://wiki.apertium.org/wiki/Post-generator for more information.-->
-    <!-- Example: This changes "a" to "an" before vowels
-    <e>
+    <!-- Example rule:
+    <e c="~a ~els → als; ~a ~el → al">
       <p>
-        <l><a/>a<b/></l>
-        <r>an<b/></r>
+        <l><a/>a<b/><a/>e</l>
+        <r/>
       </p>
-      <par n="vocals"/>
+      <p>
+        <l></l>
+        <r>a</r>
+      </p>
+      <par n="contrac"/>
     </e>
     -->
-  </section>
-</dictionary>
 
+ </section>
+</dictionary>

--- a/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.lexc
+++ b/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.lexc
@@ -39,24 +39,26 @@ if_twoc}}
 
 LEXICON Root
 
-NounRoot ;
+!! List lexicons here
+!! Example:
+! NounRoot ;
+
 Numeral ;
 Punctuation ;
 
-
-LEXICON RegNounInfl
-
-%<n%>%<sg%>: # ;
-%<n%>%<pl%>:%>s # ;
+! Example noun inflection
+! LEXICON RegNounInfl
+! %<n%>%<sg%>: # ;
+! %<n%>%<pl%>:%>s # ;
 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!                          L E X I C O N                                  !!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-LEXICON NounRoot
-
-house:house RegNounInfl ; ! A noun
+! Example lexical entries
+! LEXICON NounRoot
+! house:house RegNounInfl ; ! A noun
 
 
 LEXICON Numeral

--- a/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.lexd
+++ b/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.lexd
@@ -28,24 +28,25 @@
 ###############################################################################
 
 PATTERNS
-NounRoot RegNounInfl
+## Example inflection pattern:
+# NounRoot RegNounInfl
 Number
 Punctuation
 
 
-LEXICON RegNounInfl
-
-<n><sg>:
-<n><pl>:>s
+## Example inflection lexicon:
+# LEXICON RegNounInfl
+# <n><sg>:
+# <n><pl>:>s
 
 
 ###############################################################################
 ###                          L E X I C O N                                  ###
 ###############################################################################
 
-LEXICON NounRoot
-
-house:house   # A noun
+## Example stem lexicon:
+# LEXICON NounRoot
+# house:house   # A noun
 
 
 PATTERN Number

--- a/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.rlx
+++ b/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.rlx
@@ -2,14 +2,14 @@
 DELIMITERS = "<.>" ;
 
 # We can define sets for common tag clusters
-LIST Case = (n s) (n p) ; # A set that matches either a Noun Singular or a Noun Plural
+# LIST Case = (n s) (n p) ; # A set that matches either a Noun Singular or a Noun Plural
 
 SECTION
 # If there is a singular noun to the right, I cannot be a verb or noun.
-REMOVE (n) OR (v) IF (1 (n s)) ;
+# REMOVE (n) OR (v) IF (1 (n s)) ;
 
 # If there is a conjunction followed by a certain cohort of the same CASE as me, choose me.
-SELECT $$Case IF (1 (cnjcoo) LINK 1C $$Case) ;
+# SELECT $$Case IF (1 (cnjcoo) LINK 1C $$Case) ;
 
 # Resources:
 # http://visl.sdu.dk/cg3.html

--- a/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.spellrelax
+++ b/hfst-language-module/apertium-{{languageCode}}.{{languageCode}}.spellrelax
@@ -1,7 +1,9 @@
 [
 	! Unify apostrophe styles
-	[ ?* [ ' (->) [ %` | ʻ | ’ | ‘ | ʼ ] ] ?* ] .o.
+	[ ?* [ ' (->) [ %` | ʻ | ’ | ‘ | ʼ ] ] ?* ]
 
-	! Accept input without diacritics
-	[ ?* [ á (->) a ] ?* ]
+    ! composition operator, must appear between rules
+    ! .o.
+	! Example rule: Accept input without diacritics
+	! [ ?* [ á (->) a ] ?* ]
 ]

--- a/lttoolbox-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
+++ b/lttoolbox-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
@@ -1,42 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dictionary>
   <alphabet/>
-
   <sdefs>
-    <sdef n="n" c="Noun"/>
+    <sdef n="prn"/>
   </sdefs>
-
   <pardefs>
-    <pardef n="vocals">
+
+    <pardef n="contrac">
       <e>
-        <i>a</i>
+        <i>ls<b/></i>
       </e>
       <e>
-        <i>e</i>
-      </e>
-      <e>
-        <i>i</i>
-      </e>
-      <e>
-        <i>o</i>
-      </e>
-      <e>
-        <i>u</i>
+        <i>l<b/></i>
       </e>
     </pardef>
+
   </pardefs>
 
   <section id="main" type="standard">
+
     <!-- Define entries within <e> here. See https://wiki.apertium.org/wiki/Post-generator for more information.-->
-    <!-- Example rule: change "a" to "an" before vowels
-    <e>
+    <!-- Example rule:
+    <e c="~a ~els → als; ~a ~el → al">
       <p>
-        <l><a/>a<b/></l>
-        <r>an<b/></r>
+        <l><a/>a<b/><a/>e</l>
+        <r/>
       </p>
-      <par n="vocals"/>
+      <p>
+        <l></l>
+        <r>a</r>
+      </p>
+      <par n="contrac"/>
     </e>
     -->
-  </section>
-</dictionary>
 
+ </section>
+</dictionary>

--- a/lttoolbox-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
+++ b/lttoolbox-language-module/apertium-{{languageCode}}.post-{{languageCode}}.dix
@@ -28,6 +28,7 @@
 
   <section id="main" type="standard">
     <!-- Define entries within <e> here. See https://wiki.apertium.org/wiki/Post-generator for more information.-->
+    <!-- Example rule: change "a" to "an" before vowels
     <e>
       <p>
         <l><a/>a<b/></l>
@@ -35,6 +36,7 @@
       </p>
       <par n="vocals"/>
     </e>
+    -->
   </section>
 </dictionary>
 

--- a/lttoolbox-language-module/apertium-{{languageCode}}.{{languageCode}}.dix
+++ b/lttoolbox-language-module/apertium-{{languageCode}}.{{languageCode}}.dix
@@ -105,16 +105,20 @@
       <e><par n="numeral"/><p><l></l><r><s n="num"/></r></p></e>
     </pardef>
 
+    <!-- Example noun inflection paradigm:
     <pardef n="house__n">
       <e><p><l></l><r><s n="n"/><s n="attr"/></r></p></e>
       <e><p><l></l><r><s n="n"/><s n="sg"/></r></p></e>
       <e><p><l>s</l><r><s n="n"/><s n="pl"/></r></p></e>
     </pardef>
+    -->
   </pardefs>
 
   <section id="main" type="standard">
     <!-- Define entries within <e> here. -->
+    <!-- Example entry:
     <e lm="house"><i>house</i><par n="house__n"/></e>
+    -->
   </section>
 
   <section id="final" type="inconditional">

--- a/lttoolbox-language-module/apertium-{{languageCode}}.{{languageCode}}.rlx
+++ b/lttoolbox-language-module/apertium-{{languageCode}}.{{languageCode}}.rlx
@@ -2,14 +2,14 @@
 DELIMITERS = "<.>" ;
 
 # We can define sets for common tag clusters
-LIST Case = (n s) (n p) ; # A set that matches either a Noun Singular or a Noun Plural
+# LIST Case = (n s) (n p) ; # A set that matches either a Noun Singular or a Noun Plural
 
 SECTION
 # If there is a singular noun to the right, I cannot be a verb or noun.
-REMOVE (n) OR (v) IF (1 (n s)) ;
+# REMOVE (n) OR (v) IF (1 (n s)) ;
 
 # If there is a conjunction followed by a certain cohort of the same CASE as me, choose me.
-SELECT $$Case IF (1 (cnjcoo) LINK 1C $$Case) ;
+# SELECT $$Case IF (1 (cnjcoo) LINK 1C $$Case) ;
 
 # Resources:
 # http://visl.sdu.dk/cg3.html


### PR DESCRIPTION
@nlhowell argues that having `apertium-init` generate English rules is antithetical to Apertium's mission.

I don't currently have enough energy left to provide non-English examples in the comments, but I do have enough to ensure that the only linguistic rule that is actually compiled is in the `.twol` file, because `hfst-compose-intersect` chokes on empty transducers.

CI will probably fail until the next nightly build goes through.